### PR TITLE
CAT5-178 - Change the Installation buttons on Candyshop from Blue to Green Hex: #34FF85

### DIFF
--- a/src/sass/patterns/_buttons.scss
+++ b/src/sass/patterns/_buttons.scss
@@ -1,0 +1,21 @@
+// Buttons
+// =====
+
+$primary-color: #34FF85;
+$text-color: #272727;
+
+[class*='slds-button_brand'] {
+    background-color: $primary-color;
+    border-color: $primary-color;
+    color: $text-color !important;
+
+    &:hover {
+        color: $text-color !important;
+        background-color: #CCFFE1;
+    }
+
+    &:active {
+        background-color: $primary-color;
+        color: $text-color !important;
+    }
+}

--- a/src/sass/patterns/_manifest.scss
+++ b/src/sass/patterns/_manifest.scss
@@ -2,6 +2,7 @@
 // ========
 
 @import 'icons';
+@import 'buttons';
 @import 'truncate';
 @import 'type';
 @import 'containers';


### PR DESCRIPTION
## [CAT5-178](https://blackthornio.atlassian.net/browse/CAT5-178)

This pull request introduces styling updates to the button components in the `src/sass/patterns` directory. The changes include defining new color variables and applying them to branded buttons, as well as updating the manifest file to include the new button styles.

Styling updates for buttons:

* [`src/sass/patterns/_buttons.scss`](diffhunk://#diff-24ae7f13db74549928c44ea4efb884c74ff76ed4f20c6d5ff24232cac9498ca9R1-R21): Added new `$primary-color` and `$text-color` variables and applied them to branded buttons (`slds-button_brand`) for background, border, and text styling. Hover and active states were also defined with specific color changes.

Manifest update:

* [`src/sass/patterns/_manifest.scss`](diffhunk://#diff-db016eb3dc941f82a3198dc295b929d33051a01b090ac0288a2ff4b16c1e8ce6R5): Included the new `_buttons.scss` file in the manifest to ensure the button styles are loaded.

[CAT5-178]: https://blackthornio.atlassian.net/browse/CAT5-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ