### PR TITLE
CAT5-178 - Change the Installation buttons on Candyshop from Blue to Green Hex: #34FF85

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get upgrade -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --upgrade pip pip-tools \
+RUN pip install --no-cache-dir --upgrade pip pip-tools && \
   pip install --no-cache-dir -r requirements/prod.txt
 
 RUN \

--- a/src/sass/patterns/_buttons.scss
+++ b/src/sass/patterns/_buttons.scss
@@ -1,0 +1,21 @@
+// Buttons
+// =====
+
+$primary-color: #34FF85;
+$text-color: #272727;
+
+[class*='slds-button_brand'] {
+    background-color: $primary-color;
+    border-color: $primary-color;
+    color: $text-color !important;
+
+    &:hover {
+        color: $text-color !important;
+        background-color: #CCFFE1;
+    }
+
+    &:active {
+        background-color: $primary-color;
+        color: $text-color !important;
+    }
+}

--- a/src/sass/patterns/_buttons.scss
+++ b/src/sass/patterns/_buttons.scss
@@ -1,16 +1,14 @@
 // Buttons
 // =====
-
-$primary-color: #34FF85;
-$text-color: #272727;
+// This file contains styles for overriding the SLDS brand buttons, including hover and active states.
 
 @mixin button-text-color {
-    color: $text-color !important;
+    color: #272727 !important;
 }
 
 @mixin button-background-color {
-    background-color: $primary-color;
-    border-color: $primary-color;
+    background-color: #34FF85;
+    border-color: #34FF85;
 }
 
 .slds-button_brand {
@@ -20,6 +18,7 @@ $text-color: #272727;
     &:hover {
         @include button-text-color;
         background-color: #CCFFE1;
+        border-color: #CCFFE1;
     }
 
     &:active {

--- a/src/sass/patterns/_buttons.scss
+++ b/src/sass/patterns/_buttons.scss
@@ -28,3 +28,7 @@
         @include button-background-color;
     }
 }
+
+.slds-button_brand .slds-icon {
+    fill: #272727;
+}

--- a/src/sass/patterns/_buttons.scss
+++ b/src/sass/patterns/_buttons.scss
@@ -12,16 +12,18 @@
 }
 
 .slds-button_brand {
-    @include button-text-color;
-    @include button-background-color;
+    &:not(:disabled) {
+        @include button-background-color;
+        @include button-text-color;
+    }
 
-    &:hover {
+    &:not(:disabled):hover {
         @include button-text-color;
         background-color: #CCFFE1;
         border-color: #CCFFE1;
     }
 
-    &:active {
+    &:not(:disabled):active {
         @include button-text-color;
         @include button-background-color;
     }

--- a/src/sass/patterns/_buttons.scss
+++ b/src/sass/patterns/_buttons.scss
@@ -4,18 +4,26 @@
 $primary-color: #34FF85;
 $text-color: #272727;
 
-[class*='slds-button_brand'] {
+@mixin button-text-color {
+    color: $text-color !important;
+}
+
+@mixin button-background-color {
     background-color: $primary-color;
     border-color: $primary-color;
-    color: $text-color !important;
+}
+
+.slds-button_brand {
+    @include button-text-color;
+    @include button-background-color;
 
     &:hover {
-        color: $text-color !important;
+        @include button-text-color;
         background-color: #CCFFE1;
     }
 
     &:active {
-        background-color: $primary-color;
-        color: $text-color !important;
+        @include button-text-color;
+        @include button-background-color;
     }
 }

--- a/src/sass/patterns/_manifest.scss
+++ b/src/sass/patterns/_manifest.scss
@@ -2,6 +2,7 @@
 // ========
 
 @import 'icons';
+@import 'buttons';
 @import 'truncate';
 @import 'type';
 @import 'containers';


### PR DESCRIPTION
## [CAT5-178](https://blackthornio.atlassian.net/browse/CAT5-178)
 
This pull request introduces styling updates for buttons in the application, including the addition of a new primary color and hover/active state styles. It also updates the Sass manifest file to include the new button styles.

Styling updates:

* [`src/sass/patterns/_buttons.scss`](diffhunk://#diff-24ae7f13db74549928c44ea4efb884c74ff76ed4f20c6d5ff24232cac9498ca9R1-R21): Added styles for branded buttons, including a new `$primary-color` (#34FF85) and `$text-color` (#272727). Defined hover and active states with specific background and text color changes.

Manifest updates:

* [`src/sass/patterns/_manifest.scss`](diffhunk://#diff-db016eb3dc941f82a3198dc295b929d33051a01b090ac0288a2ff4b16c1e8ce6R5): Imported the new `_buttons.scss` file to ensure the button styles are included in the application's Sass compilation.

[CAT5-178]: https://blackthornio.atlassian.net/browse/CAT5-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ