### PR TITLE
MT-433 - Product Banners on Candyshop reference a blue button that is green

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -100,7 +100,7 @@
   "Salesforce Org Information": "Salesforce Org Information",
   "Sandbox or Scratch Org": "Sandbox or Scratch Org",
   "Scratch Org": "Scratch Org",
-  "Select a Plan": "Click on the Blue Button to install or click the ‘Product Upgrade’ button to update your app.",
+  "Select a Plan": "Click on the Green Button to install or click the ‘Product Upgrade’ button to update your app.",
   "Select a Product to Install": "Select an Application to Install into your Salesforce Environment",
   "Select a different plan": "Select a different plan",
   "Select a different product": "Select a different product",


### PR DESCRIPTION
## [MT-433](https://blackthornio.atlassian.net/browse/MT-433)

This pull request includes a small change to the `locales/en/translation.json` file. The change updates the text for the "Select a Plan" translation to specify clicking on a green button instead of a blue button.

[MT-433]: https://blackthornio.atlassian.net/browse/MT-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ