### PR TITLE
feat: enable PKCE S256 on Salesforce OAuth user-login

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Store robot results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: robot
           path: robot/results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Test frontend
         run: docker-compose run --no-deps web yarn test:js:coverage
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage
           path: |
@@ -67,7 +67,7 @@ jobs:
           -e SFDX_HUB_KEY="sample key"
           web yarn test:py
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
           path: |

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -361,6 +361,10 @@ if GITHUB_APP_KEY and not GITHUB_APP_ID:
 SOCIALACCOUNT_PROVIDERS = {
     "salesforce": {
         "SCOPE": ["web", "full", "refresh_token"],
+        # Defense-in-depth: send PKCE S256 on the user-login flow. The connected
+        # app does not need to *require* PKCE for this to work — when a challenge
+        # is presented, Salesforce validates it against the code_verifier.
+        "OAUTH_PKCE_ENABLED": True,
         "APP": {
             "client_id": SFDX_CLIENT_ID,
             "secret": SFDX_CLIENT_SECRET,

--- a/docs/plans/2026-05-21-oauth-pkce.md
+++ b/docs/plans/2026-05-21-oauth-pkce.md
@@ -1,0 +1,73 @@
+# OAuth PKCE for the Salesforce user-login flow
+
+**Date:** 2026-05-21
+**Branch:** `feature/oauth-pkce`
+**PR:** [#19](https://github.com/blackthornio/package-installer/pull/19)
+**Status:** Implementation merged-ready, awaiting CI + manual sandbox verification
+
+## Goal
+
+Add Proof Key for Code Exchange (PKCE, RFC 7636) S256 to the Salesforce OAuth flow that users go through when logging in to the package installer.
+
+## Scope
+
+User-login flow only (`sfdo_template_helpers.oauth2.salesforce` via django-allauth). Scratch-org `AuthCode` redemption, the Dev Hub JWT path, and refresh-token grants are out of scope: none of them are browser-mediated authorization-code flows, so PKCE has nothing to protect.
+
+## Where the connected app credentials live
+
+The Salesforce connected app's consumer key/secret and callback URL are read from env vars in `config/settings/base.py:311-334`:
+
+- `SFDX_CLIENT_ID` / `SFDX_CLIENT_SECRET` (legacy aliases `CONNECTED_APP_CLIENT_ID/SECRET`).
+- `SFDX_CLIENT_CALLBACK_URL`.
+
+Required at startup (`ImproperlyConfigured` if missing). Wired into `SOCIALACCOUNT_PROVIDERS["salesforce"]["APP"]`, into a CumulusCI `ServiceConfig` in `metadeploy/api/jobs.py`, and into `metadeploy/api/salesforce.py`. Per-env values come from `.env` locally, env vars in `docker-compose.yml` / `Procfile` / `Dockerfile`, `app.json` for Heroku, and GitHub Actions secrets for CI.
+
+No new env vars introduced by this work; PKCE is purely additive on the wire.
+
+## Decision
+
+Upgrade `django-allauth` 0.51.0 → 0.52.0 and flip the per-provider PKCE flag. allauth 0.52 added the full PKCE plumbing:
+
+- `OAuth2Client.get_access_token(code, pkce_code_verifier=None)`.
+- `OAuth2LoginView.login` auto-generates the challenge and stashes the verifier in `session["pkce_code_verifier"]`.
+- `OAuth2Adapter.get_access_token_data` auto-pops the verifier and forwards it.
+- Opt-in via `SOCIALACCOUNT_PROVIDERS["<provider>"]["OAUTH_PKCE_ENABLED"] = True`.
+
+Net cost in this repo: a settings flag, an allauth pin bump, and one unit test. No subclasses, no fork, no monkey-patching.
+
+## Compatibility audit (justifies the 0.51 → 0.52 bump)
+
+- **Django pin** (`django==3.2.14`) is supported by allauth 0.52 (range 2.0–4.1). ✓
+- **`sfdo-template-helpers v0.20.0`** does not pin allauth (declares it only as an extras dep, unbounded). ✓
+- **`socialaccount_state` session shape** — read directly by `sfdo_template_helpers`' `complete_login` as `session["socialaccount_state"][1]` — is byte-identical between 0.51 and 0.52. The PKCE verifier lives in a different session key (`pkce_code_verifier`), no collision. ✓
+- **Transitive deps**: 0.51 → 0.52 `install_requires` is identical. No cascading lockfile churn. ✓
+- **0.52 changelog**: PKCE flag (additive), Django 4.1 support, three new providers (irrelevant), `ACCOUNT_PREVENT_ENUMERATION` extension (gated by a setting we don't enable; we have `ACCOUNT_EMAIL_VERIFICATION = "none"`), Google/Pinterest URL fixes (irrelevant). No removals, no deprecations. ✓
+
+## Backward compatibility
+
+Two switches that compose orthogonally:
+
+| | Client sends PKCE | Client doesn't |
+|---|---|---|
+| **Connected app requires PKCE** | works | rejected by Salesforce |
+| **Connected app doesn't require** | works (Salesforce validates if provided) | works (legacy path) |
+
+Enabling `OAUTH_PKCE_ENABLED` while the connected-app toggle is off lands us in the top-left cell — the goal. **No connected-app changes shipped in this PR.**
+
+### Rollout safety
+
+- Login that started before deploy, completes after: `/authorize` had no challenge, session has no verifier, allauth sends no `code_verifier` on `/token`, Salesforce (toggle off) accepts. Login completes. ✓
+- Login started after deploy: PKCE on both sides. ✓
+
+No stuck-mid-flow scenario.
+
+## Verification
+
+- [x] New unit test asserting `code_challenge` + `code_challenge_method=S256` on the `/authorize` redirect, and that the verifier lands in `session["pkce_code_verifier"]`.
+- [ ] CI green on PR #19 (`yarn test:py` + frontend lint).
+- [ ] Manual: log in to a sandbox via the running dev container; confirm a clean end-to-end login.
+
+## Follow-ups (separate tickets)
+
+1. Flip "Require Proof Key for Code Exchange" on the Salesforce connected app once PKCE has been live in prod for a release cycle.
+2. Consider whether to drop `client_secret` once PKCE is required. Current decision: keep it (confidential client + PKCE for defense in depth).

--- a/metadeploy/tests/test_views.py
+++ b/metadeploy/tests/test_views.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from allauth.socialaccount.providers.oauth2.client import OAuth2Error
@@ -62,3 +63,17 @@ def test_custom_500_view__ip_restricted_error(render):
             custom_500_view(request)
 
     assert allow_list == render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
+
+
+@pytest.mark.django_db
+def test_salesforce_login_uses_pkce(client, social_app):
+    # allauth renders a confirmation page on GET; POST drives the actual redirect.
+    response = client.post("/accounts/salesforce/login/")
+    assert response.status_code == 302
+
+    query = parse_qs(urlparse(response["Location"]).query)
+    assert query.get("code_challenge_method") == ["S256"]
+    assert query.get("code_challenge"), "missing code_challenge on /authorize redirect"
+    assert client.session.get(
+        "pkce_code_verifier"
+    ), "PKCE verifier must be stashed in the session for the callback step"

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -12,7 +12,7 @@ bleach
 boto3
 channels
 channels-redis
-django-allauth
+django-allauth>=0.52  # 0.52 added per-provider OAUTH_PKCE_ENABLED
 django-colorfield
 django-binary-database-files
 django-environ

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -121,7 +121,7 @@ django==3.2.14
     #   django-storages
     #   djangorestframework
     #   sfdo-template-helpers
-django-allauth==0.51.0
+django-allauth==0.52.0
     # via -r requirements/prod.in
 django-binary-database-files==1.0.15
     # via -r requirements/prod.in


### PR DESCRIPTION
## Summary

- Bumps `django-allauth` 0.51.0 → 0.52.0 (additive minor; identical transitive deps).
- Sets `OAUTH_PKCE_ENABLED: True` on the `salesforce` provider. The user-login flow now sends `code_challenge` / `code_challenge_method=S256` on `/authorize` and `code_verifier` on `/token`.
- Defense in depth — the Salesforce connected app does **not** need to require PKCE for this to take effect; when a challenge is presented, Salesforce validates it against the verifier.

## Scope

User-login flow only. Scratch-org provisioning (`metadeploy/api/salesforce.py`) and the Dev Hub JWT path are unaffected: neither involves a browser or an `/authorize` hop, so PKCE has nothing to protect there.

## Test plan

- [x] `pytest metadeploy/tests/test_views.py::test_salesforce_login_uses_pkce` (new) — asserts `code_challenge` + `code_challenge_method=S256` on the `/authorize` redirect and that the verifier is stashed in the session for the callback step.
- [ ] CI: full `yarn test:py` green.
- [ ] Manual: log in to a sandbox via the running app, confirm a successful end-to-end login.